### PR TITLE
Making ctx global variable

### DIFF
--- a/src/tetris.js
+++ b/src/tetris.js
@@ -2,12 +2,14 @@ import { BOARD_WIDTH, BOARD_HEIGHT, KEY } from './constants';
 import { Tetronimo } from './piece';
 import { Board } from './board';
 
+let ctx = null;
+
 window.addEventListener('load', () => {
     /*---------------
     CANVAS AND CONTEXT
     ----------------*/
     const canvas = document.getElementById('board');
-    const ctx = canvas.getContext('2d');
+    ctx = canvas.getContext('2d');
     const canvasNext = document.getElementById('upcoming');
     const ctxNext = canvasNext.getContext('2d');
 
@@ -27,7 +29,6 @@ window.addEventListener('load', () => {
     playButton.addEventListener('click', () => {
         //call the function that starts the game
         start();
-        console.log('play button is pressed');
     });
 });
 


### PR DESCRIPTION
Previously the `ctx` variable was a local variable to the window.load callback function. So when you tried to access it in the `start` function the value of it would have been `undefined`.

screenshot:
<img width="585" alt="Screenshot 2021-12-30 at 20 05 56" src="https://user-images.githubusercontent.com/7311745/147784935-a4f8996b-fec7-4487-a401-70d92ad2a35d.png">

